### PR TITLE
Add Weekly Evaluation drawer and link it to dummy data

### DIFF
--- a/app/backend/data/evaluations.json
+++ b/app/backend/data/evaluations.json
@@ -1,0 +1,31 @@
+[
+  {
+    "id": 1,
+    "memberId": 1,
+    "teamName": "Team Beacon",
+    "teamRole": "Team Lead",
+    "reports": [
+      {
+        "weekLabel": "Week 6",
+        "status": "Making progress",
+        "mood": "🙂",
+        "notes": "Team rallied for usability testing; still working on slide polish.",
+        "updatedAt": "Nov 15, 2025"
+      },
+      {
+        "weekLabel": "Week 5",
+        "status": "At Risk",
+        "mood": "😟",
+        "notes": "Stand-up slipped; scheduling conflict with two members—reset cadence with shared calendar.",
+        "updatedAt": "Nov 8, 2025"
+      },
+      {
+        "weekLabel": "Week 4",
+        "status": "On Track",
+        "mood": "😊",
+        "notes": "Delivered detailed retro summary to Prof. Lin, highlighting peer praise and action items.",
+        "updatedAt": "Nov 1, 2025"
+      }
+    ]
+  }
+]

--- a/app/backend/repositories/EvaluationsRepository.js
+++ b/app/backend/repositories/EvaluationsRepository.js
@@ -1,0 +1,7 @@
+class EvaluationsRepository {
+  async getEvaluationByMemberId(_memberId) {
+    throw new Error('getEvaluationByMemberId() must be implemented');
+  }
+}
+
+module.exports = EvaluationsRepository;

--- a/app/backend/repositories/implementations/JsonEvaluationsRepository.js
+++ b/app/backend/repositories/implementations/JsonEvaluationsRepository.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const EvaluationsRepository = require('../EvaluationsRepository');
+
+const EVALUATIONS_FILE_PATH = path.join(__dirname, '../../data/evaluations.json');
+
+class JsonEvaluationsRepository extends EvaluationsRepository {
+  constructor() {
+    super();
+    this.filePath = EVALUATIONS_FILE_PATH;
+  }
+
+  _readFile() {
+    if (!fs.existsSync(this.filePath)) {
+      return [];
+    }
+    const data = fs.readFileSync(this.filePath, 'utf8');
+    return JSON.parse(data);
+  }
+
+  async getEvaluationByMemberId(memberId) {
+    const evaluations = this._readFile();
+    const evaluation = evaluations.find((entry) => entry.memberId === parseInt(memberId, 10));
+    return evaluation || null;
+  }
+}
+
+module.exports = JsonEvaluationsRepository;

--- a/app/backend/repositories/repositoryFactory.js
+++ b/app/backend/repositories/repositoryFactory.js
@@ -1,4 +1,5 @@
 const JsonTeamsRepository = require('./implementations/JsonTeamsRepository');
+const JsonEvaluationsRepository = require('./implementations/JsonEvaluationsRepository');
 // const PostgresTeamsRepository = require('./implementations/PostgresTeamsRepository');
 
 /**
@@ -21,6 +22,15 @@ class RepositoryFactory {
       // case 'postgres':
       //   return new PostgresTeamsRepository();
       
+      default:
+        throw new Error(`Unknown storage type: ${this.storageType}`);
+    }
+  }
+
+  createEvaluationsRepository() {
+    switch (this.storageType) {
+      case 'json':
+        return new JsonEvaluationsRepository();
       default:
         throw new Error(`Unknown storage type: ${this.storageType}`);
     }

--- a/app/backend/server.js
+++ b/app/backend/server.js
@@ -17,6 +17,7 @@ app.use(express.json()); // Parse JSON bodies
 
 // Initialize repository
 const teamsRepository = repositoryFactory.createTeamsRepository();
+const evaluationsRepository = repositoryFactory.createEvaluationsRepository();
 // Serve static files from frontend/public
 app.use(express.static(path.join(__dirname, '../frontend/public')));
 
@@ -197,6 +198,32 @@ app.get('/api/teams', async (req, res) => {
   } catch (error) {
     console.error('Error fetching teams:', error);
     res.status(500).json({ error: 'Failed to fetch teams' });
+  }
+});
+
+// GET weekly evaluation data by member ID
+app.get('/api/evaluations/:memberId', async (req, res) => {
+  try {
+    const memberId = parseInt(req.params.memberId, 10);
+    const evaluation = await evaluationsRepository.getEvaluationByMemberId(memberId);
+
+    if (!evaluation) {
+      return res.status(404).json({ error: 'Evaluation not found' });
+    }
+
+    const members = getMembers();
+    const member = members.find((m) => m.id === memberId);
+
+    res.json({
+      memberId,
+      memberName: member?.name || evaluation.memberName || 'Team Member',
+      memberRole: evaluation.teamRole || member?.role || 'student',
+      teamName: evaluation.teamName || '',
+      reports: evaluation.reports || [],
+    });
+  } catch (error) {
+    console.error('Error fetching evaluation:', error);
+    res.status(500).json({ error: 'Failed to fetch evaluation' });
   }
 });
 

--- a/app/frontend/src/pages/dashboards/script.js
+++ b/app/frontend/src/pages/dashboards/script.js
@@ -1,3 +1,30 @@
+const evaluationCache = new Map();
+
+const statusToMood = (status = '') => {
+  if (/risk|off track/i.test(status)) return '😟';
+  if (/progress|needs support/i.test(status)) return '🙂';
+  return '😊';
+};
+
+const fetchEvaluationData = async (memberId) => {
+  if (!memberId) {
+    throw new Error('Missing member ID for evaluation');
+  }
+
+  if (evaluationCache.has(memberId)) {
+    return evaluationCache.get(memberId);
+  }
+
+  const response = await fetch(`/api/evaluations/${memberId}`);
+  if (!response.ok) {
+    throw new Error('Failed to load evaluation data');
+  }
+
+  const data = await response.json();
+  evaluationCache.set(memberId, data);
+  return data;
+};
+
 const setupProfilePanel = () => {
   const panel = document.querySelector('.profile-panel');
   if (!panel) return;
@@ -39,4 +66,125 @@ const setupProfilePanel = () => {
   });
 };
 
-document.addEventListener('DOMContentLoaded', setupProfilePanel);
+const setupEvaluationPanel = () => {
+  const panel = document.querySelector('.evaluation-panel');
+  if (!panel) return;
+  const closeBtn = panel.querySelector('.close-evaluation');
+  const contextTitle = panel.querySelector('[data-eval-context]');
+  const triggers = document.querySelectorAll('.evaluation-trigger');
+  const weekFilter = panel.querySelector('[data-week-filter]');
+  const moodFace = panel.querySelector('[data-mood-face]');
+  const moodStatus = panel.querySelector('[data-mood-status]');
+  const moodMeta = panel.querySelector('[data-mood-meta]');
+  const notesTarget = panel.querySelector('[data-eval-notes]');
+
+  let currentReports = [];
+  let currentMemberId = null;
+
+  const renderEmptyState = (message) => {
+    if (moodFace) moodFace.textContent = '😐';
+    if (moodStatus) moodStatus.textContent = 'Unavailable';
+    if (moodMeta) moodMeta.textContent = '';
+    if (notesTarget) notesTarget.textContent = message;
+    if (weekFilter) weekFilter.innerHTML = '';
+  };
+
+  const applyReport = (report) => {
+    if (!report) {
+      renderEmptyState('No evaluation data for this week.');
+      return;
+    }
+    if (moodFace) moodFace.textContent = report.mood || statusToMood(report.status);
+    if (moodStatus) moodStatus.textContent = report.status || 'On Track';
+    if (moodMeta) {
+      const meta = report.updatedAt ? `Updated ${report.updatedAt}` : report.weekLabel ? `Captured for ${report.weekLabel}` : '';
+      moodMeta.textContent = meta;
+    }
+    if (notesTarget) notesTarget.textContent = report.notes || 'No notes recorded for this week.';
+  };
+
+  const populateWeeks = (reports = []) => {
+    if (!weekFilter) return;
+    weekFilter.innerHTML = '';
+    currentReports = reports;
+
+    if (!reports.length) {
+      renderEmptyState('No evaluation notes yet for this member.');
+      return;
+    }
+
+    reports.forEach((report, index) => {
+      const option = document.createElement('option');
+      option.value = String(index);
+      option.textContent = report.weekLabel || report.label || `Week ${index + 1}`;
+      if (index === 0) option.selected = true;
+      weekFilter.appendChild(option);
+    });
+
+    applyReport(reports[0]);
+  };
+
+  const loadAndRender = async (memberId) => {
+    try {
+      const evaluation = await fetchEvaluationData(memberId);
+      const displayName = [evaluation.memberName, evaluation.teamName].filter(Boolean).join(' · ');
+      if (contextTitle) {
+        contextTitle.textContent = displayName || 'Team Member';
+      }
+      populateWeeks(evaluation.reports || []);
+    } catch (error) {
+      console.error('Weekly evaluation error:', error);
+      renderEmptyState('Unable to load evaluation for this member right now.');
+      if (contextTitle) {
+        contextTitle.textContent = 'Team Member';
+      }
+    }
+  };
+
+  const openPanel = (trigger) => {
+    currentMemberId = trigger?.dataset?.memberId;
+    panel.classList.add('active');
+    panel.setAttribute('aria-hidden', 'false');
+    trigger?.setAttribute('aria-expanded', 'true');
+    renderEmptyState('Loading evaluation…');
+    loadAndRender(currentMemberId);
+  };
+
+  const closePanel = () => {
+    panel.classList.remove('active');
+    panel.setAttribute('aria-hidden', 'true');
+    triggers.forEach((trigger) => trigger.setAttribute('aria-expanded', 'false'));
+  };
+
+  weekFilter?.addEventListener('change', (event) => {
+    const index = parseInt(event.target.value, 10);
+    if (!Number.isNaN(index)) {
+      applyReport(currentReports[index]);
+    }
+  });
+
+  triggers.forEach((trigger) => {
+    trigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      openPanel(trigger);
+    });
+  });
+
+  closeBtn?.addEventListener('click', closePanel);
+  panel.addEventListener('click', (event) => {
+    if (event.target === panel) {
+      closePanel();
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closePanel();
+    }
+  });
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupProfilePanel();
+  setupEvaluationPanel();
+});

--- a/app/frontend/src/pages/dashboards/student.html
+++ b/app/frontend/src/pages/dashboards/student.html
@@ -167,6 +167,5 @@
             });
             */
         </script>
-    </section>
 </body>
 </html>

--- a/app/frontend/src/pages/dashboards/student.html
+++ b/app/frontend/src/pages/dashboards/student.html
@@ -62,17 +62,47 @@
                 <div class="card-icon">📈</div>
                 <div class="card-content">
                     <h2>Weekly Evaluation</h2>
-                    <p>Review performance summaries and submit weekly feedback reports.</p>
-                    <button class="card-btn">View Evaluation</button>
+                    <p>Review your notes and mood score by selecting a timeframe.</p>
+                    <button class="card-btn evaluation-trigger" data-member-id="1" aria-expanded="false">
+                        View Evaluation
+                    </button>
                 </div>
             </article>
-
         </section>
 
     </div>
 
     <section class="profile-panel" id="profile-panel" aria-hidden="true">
     <!-- Profile panel removed, navigation now goes to profile page -->
+    </section>
+
+    <section class="evaluation-panel" aria-hidden="true">
+        <article class="evaluation-drawer">
+            <header>
+                <div>
+                    <p class="meta-label">Weekly evaluation</p>
+                    <h2 data-eval-context>Jordan Lee · Team Beacon</h2>
+                    <p>Mood score and notes update as you change the week.</p>
+                </div>
+                <button class="close-evaluation" aria-label="Close weekly evaluation">×</button>
+            </header>
+            <div class="evaluation-filter">
+                <label for="student-week">Filter by week</label>
+                <select id="student-week" data-week-filter></select>
+            </div>
+            <div class="mood-display">
+                <div class="evaluation-face" data-mood-face>😊</div>
+                <div>
+                    <p class="mood-status" data-mood-status>On track</p>
+                    <p class="mood-meta" data-mood-meta>Captured for Week 6</p>
+                </div>
+            </div>
+            <div class="notes-panel">
+                <label>Evaluation notes</label>
+                <p data-eval-notes>Notes for the selected week will appear here.</p>
+            </div>
+        </article>
+    </section>
 
     <script src="script.js"></script>
         <script>

--- a/app/frontend/src/pages/dashboards/style.css
+++ b/app/frontend/src/pages/dashboards/style.css
@@ -385,6 +385,149 @@ body {
   font-weight: 600;
 }
 
+.evaluation-card {
+  background: var(--card);
+  border-radius: 18px;
+  padding: 24px;
+  border: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 18px;
+}
+
+.evaluation-card header {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.evaluation-card small {
+  color: var(--subtle);
+}
+
+.evaluation-card .evaluation-trigger {
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(47, 59, 181, 0.2);
+  
+}
+
+.evaluation-mood {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.evaluation-face {
+  width: 60px;
+  height: 60px;
+  border-radius: 18px;
+  background: rgba(87, 184, 148, 0.15);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.8rem;
+}
+
+.evaluation-panel {
+  position: fixed;
+  inset: 0;
+  background: rgba(21, 27, 53, 0.7);
+  display: none;
+  justify-content: flex-end;
+  z-index: 30;
+}
+
+.evaluation-panel.active {
+  display: flex;
+}
+
+.evaluation-drawer {
+  width: min(460px, 100%);
+  background: var(--card);
+  border-left: 1px solid var(--border);
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  box-shadow: -20px 0 45px rgba(5, 13, 57, 0.25);
+}
+
+.evaluation-drawer header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.close-evaluation {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: var(--subtle);
+}
+
+.evaluation-filter label,
+.notes-panel label {
+  font-weight: 600;
+  margin-bottom: 6px;
+  display: block;
+}
+
+.evaluation-filter select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  background: #f8f9ff;
+  font-size: 0.95rem;
+}
+
+.mood-display {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  background: #fdfdfd;
+}
+
+.mood-display .evaluation-face {
+  width: 72px;
+  height: 72px;
+  font-size: 2rem;
+}
+
+.mood-status {
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.mood-meta {
+  color: var(--subtle);
+  font-size: 0.9rem;
+}
+
+.notes-panel {
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 16px;
+  background: #fefefe;
+}
+
+.notes-panel p {
+  margin-top: 8px;
+  line-height: 1.5;
+  color: var(--text);
+}
+
 @media (max-width: 1100px) {
   .content-grid {
     grid-template-columns: 1fr;

--- a/app/frontend/src/pages/dashboards/ta.html
+++ b/app/frontend/src/pages/dashboards/ta.html
@@ -120,6 +120,5 @@
                 document.getElementById('profEmail').textContent = email;
             });
         </script>
-    </section>
 </body>
 </html>

--- a/app/frontend/src/pages/dashboards/ta.html
+++ b/app/frontend/src/pages/dashboards/ta.html
@@ -57,12 +57,14 @@
                     <button class="card-btn">Open Journal</button>
                 </div>
             </article>
+
         </section>
 
     </div>
 
     <section class="profile-panel" id="profile-panel" aria-hidden="true">
     <!-- Profile panel removed, navigation now goes to profile page -->
+    </section>
 
     <script src="script.js"></script>
         <script>

--- a/app/frontend/src/pages/dashboards/team_lead.html
+++ b/app/frontend/src/pages/dashboards/team_lead.html
@@ -7,14 +7,14 @@
     <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-    <div class="page" data-role="student">
+    <div class="page" data-role="team-lead">
         <header class="top-nav">
             <div class="brand">Conductor <span>App</span></div>
             <div class="nav-actions">
                 <div class="profile">
                     <div class="profile-dropdown-container" style="position:relative;">
-                        <img id="dashboardProfileImg" src="/assets/logo/user.png" alt="Profile" style="width:32px;height:32px;border-radius:50%;object-fit:cover;cursor:pointer;" />
-                        <div class="profile-dropdown" id="profileDropdown" style="display:none; position:absolute; top:40px; right:0; background:#fff; border:1px solid #ddd; border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.08); min-width:140px; z-index:10;">
+                        <img id="dashboardProfileImg" src="/assets/logo/user.png" alt="Profile" style="width:44px;height:44px;border-radius:50%;object-fit:cover;cursor:pointer;" />
+                        <div class="profile-dropdown" id="profileDropdown" style="display:none; position:absolute; top:48px; right:0; background:#fff; border:1px solid #ddd; border-radius:8px; box-shadow:0 2px 8px rgba(0,0,0,0.08); min-width:140px; z-index:10;">
                             <a href="/profile_page/profile.html" style="display:block; padding:10px 16px; color:#222; text-decoration:none;">Profile</a>
                             <a href="#" id="logoutBtn" style="display:block; padding:10px 16px; color:#d00; text-decoration:none;">Log Out</a>
                         </div>
@@ -25,8 +25,8 @@
 
         <section class="dashboard-header">
             <div>
-                <h1>Student Dashboard</h1>
-                <small>Team Lead view · CSE 210 </small>
+                <h1>Team Lead Dashboard</h1>
+                <small>Team Beacon · Weekly rituals</small>
             </div>
         </section>
 
@@ -35,22 +35,22 @@
                 <div class="card-icon">📘</div>
                 <div class="card-content">
                     <h2>Class Directory</h2>
-                    <p>View and manage all staff and student class information.</p>
-                    <button class="card-btn">Open</button>
+                    <p>Jump to your section roster, mentor assignments, and office hours.</p>
+                    <button class="card-btn">Open Directory</button>
                 </div>
             </article>
 
             <article class="dashboard-card">
                 <div class="card-icon">🗂️</div>
                 <div class="card-content">
-                    <h2>Task Tracker</h2>
-                    <p>Monitor assigned tasks, due dates, and progress updates.</p>
-                    <button id="viewTasksBtn" class="card-btn">View Tasks</button>
+                    <h2>Team Task Tracker</h2>
+                    <p>Highlight priority tasks and keep owners aligned.</p>
+                    <button class="card-btn" id="viewTasksBtn">View Tasks</button>
                 </div>
             </article>
 
             <article class="dashboard-card">
-                <div class="card-icon">📝</div>
+                <div class="card-icon">👥</div>
                 <div class="card-content">
                     <h2>Work Journal</h2>
                     <p>Create, organize, or review your meeting notes and class discussions.</p>
@@ -62,17 +62,8 @@
                 <div class="card-icon">📈</div>
                 <div class="card-content">
                     <h2>Weekly Evaluation</h2>
-                    <p>Review performance summaries and submit weekly feedback reports.</p>
-                    <button class="card-btn">View Evaluation</button>
-                </div>
-            </article>
-
-            <article class="dashboard-card">
-                <div class="card-icon">📊</div>
-                <div class="card-content">
-                    <h2>Evaluation Journal</h2>
-                    <p>Review performance metrics and grading insights for your classes.</p>
-                    <button class="card-btn">Open Journal</button>
+                    <p>Set the mood score and collect direct quotes for each week.</p>
+                    <button class="card-btn evaluation-trigger" data-member-id="1" aria-expanded="false">View Evaluation</button>
                 </div>
             </article>
         </section>
@@ -83,10 +74,38 @@
     <!-- Profile panel removed, navigation now goes to profile page -->
     </section>
 
+    <section class="evaluation-panel" aria-hidden="true">
+        <article class="evaluation-drawer">
+            <header>
+                <div>
+                    <p class="meta-label">Weekly evaluation</p>
+                    <h2 data-eval-context>Beacon AR · Team Lead</h2>
+                    <p>Use the week selector to swap notes and mood scores.</p>
+                </div>
+                <button class="close-evaluation" aria-label="Close weekly evaluation">×</button>
+            </header>
+            <div class="evaluation-filter">
+                <label for="lead-week">Filter by week</label>
+                <select id="lead-week" data-week-filter></select>
+            </div>
+            <div class="mood-display">
+                <div class="evaluation-face" data-mood-face>🙂</div>
+                <div>
+                    <p class="mood-status" data-mood-status>Making progress</p>
+                    <p class="mood-meta" data-mood-meta>Captured for Week 6</p>
+                </div>
+            </div>
+            <div class="notes-panel">
+                <label>Evaluation notes</label>
+                <p data-eval-notes>Notes for the selected week will appear here.</p>
+            </div>
+        </article>
+    </section>
+
     <script src="script.js"></script>
         <script>
             document.getElementById('viewTasksBtn').addEventListener('click', function() {
-            window.location.href = '/task_tracker/task_tracker.html';
+                window.location.href = '/task_tracker/task_tracker.html';
             });
         </script>
         <script>
@@ -114,12 +133,10 @@
             });
             document.getElementById('logoutBtn').addEventListener('click', function(e) {
                 e.preventDefault();
-                // Clear localStorage and redirect to login
                 localStorage.clear();
                 window.location.href = '/login';
             });
         </script>
-
         <script>
             window.addEventListener('DOMContentLoaded', function() {
                 var savedImg = localStorage.getItem('profileImg');


### PR DESCRIPTION
- Added a dedicated evaluation data source (data/evaluations.json) plus a lightweight repository/route so the backend can serve weekly reports by member ID. (subject to change depending on backend config)
- Updated the dashboard JS/HTML so student and team-lead “View Evaluation” buttons fetch /api/evaluations/:memberId, populate the drawer, and cache results; TA dashboard no longer shows the drawer entry point.
- Expanded the shared dashboard styles to support the new drawer layout (filter select, mood display, notes panel) and ensured the markup follows the existing card grid patterns.


