### PR TITLE
added role-based access

### DIFF
--- a/app/backend/data/team_assignments.json
+++ b/app/backend/data/team_assignments.json
@@ -1,0 +1,67 @@
+{
+    "tas": [
+      {
+        "id": 1,
+        "name": "Sarah Chen",
+        "initials": "SC",
+        "email": "sarah.chen@conductor.edu",
+        "role": "Teaching Assistant",
+        "teams": [1, 2, 3]
+      },
+      {
+        "id": 2,
+        "name": "Daniel Rivera",
+        "initials": "DR",
+        "email": "daniel.rivera@conductor.edu",
+        "role": "Teaching Assistant",
+        "teams": [1]
+      },
+      {
+        "id": 3,
+        "name": "Priya Natarajan",
+        "initials": "PN",
+        "email": "priya.natarajan@conductor.edu",
+        "role": "Teaching Assistant",
+        "teams": [2]
+      },
+      {
+        "id": 4,
+        "name": "Omar Hassan",
+        "initials": "OH",
+        "email": "omar.hassan@conductor.edu",
+        "role": "Teaching Assistant",
+        "teams": [3]
+      }
+    ],
+    "teamLeads": [
+      {
+        "id": 101,
+        "name": "Alex Morgan",
+        "initials": "AM",
+        "email": "alex.morgan@conductor.edu",
+        "role": "team_lead",
+        "teams": [1]
+      },
+      {
+        "id": 102,
+        "name": "Casey Lee",
+        "initials": "CL",
+        "email": "casey.lee@conductor.edu",
+        "role": "team_lead",
+        "teams": [2]
+      },
+      {
+        "id": 103,
+        "name": "Harper Martinez",
+        "initials": "HM",
+        "email": "harper.martinez@conductor.edu",
+        "role": "team_lead",
+        "teams": [3]
+      }
+    ],
+    "metadata": {
+      "description": "Role-to-team assignments for TAs and team leads used by Team Card and related features.",
+      "teamsSource": "app/backend/data/teams.json",
+      "membersSource": "app/backend/data/members.json"
+    }
+  }

--- a/app/backend/server.js
+++ b/app/backend/server.js
@@ -892,6 +892,46 @@ app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, '../frontend/public/index.html'));
 });
 
+// --- Team assignments helper & endpoint (for Team Card access control) ---
+
+const teamAssignmentsPath = path.join(__dirname, 'data', 'team_assignments.json');
+
+/**
+ * Safely read team assignments from JSON file.
+ * If the file doesn't exist or is invalid, returns a default structure.
+ */
+function getTeamAssignments() {
+  try {
+    if (!fs.existsSync(teamAssignmentsPath)) {
+      // Default empty structure
+      return { tas: [], teamLeads: [], metadata: {} };
+    }
+    const raw = fs.readFileSync(teamAssignmentsPath, 'utf8');
+    const data = JSON.parse(raw);
+
+    // Ensure expected structure
+    return {
+      tas: Array.isArray(data.tas) ? data.tas : [],
+      teamLeads: Array.isArray(data.teamLeads) ? data.teamLeads : [],
+      metadata: data.metadata || {}
+    };
+  } catch (error) {
+    console.error('Error reading team_assignments.json:', error);
+    return { tas: [], teamLeads: [], metadata: {} };
+  }
+}
+
+/**
+ * Expose assignments to the frontend.
+ * NOTE: This is read-only and does NOT enforce security; it's for UI filtering.
+ */
+app.get('/api/team-assignments', (req, res) => {
+  const assignments = getTeamAssignments();
+  res.json(assignments);
+});
+
+// --- end team assignments helpers ---
+
 if (require.main === module) {
   app.listen(PORT, () => {
     console.log(`Server running at http://localhost:${PORT}`);


### PR DESCRIPTION
### Summary
Adds role-based filtering to the Team Card page so users only see teams they're authorized to view. Professors see all teams, TAs see their assigned teams, and team leads see only their own team.

### Changes

**Backend:**
- Added `app/backend/data/team_assignments.json` mapping TAs and team leads to team IDs
- Added `GET /api/team-assignments` endpoint to serve assignment data
- Added `getTeamAssignments()` helper to safely read the JSON file

**Frontend:**
- Updated `team_card.html` to fetch both teams and assignments
- Added `getAccessibleTeamIds()` helper that filters teams based on:
  - User role (from `localStorage.role`)
  - User email/name (from `localStorage`)
  - Assignment mappings from `team_assignments.json`
- Updated `loadTeams()` to render only accessible teams

### Access Rules
- **Professor**: sees all teams
- **Teaching Assistant**: sees only teams assigned in `team_assignments.json` (matched by email or name)
- **Team Lead**: sees only their assigned team (matched by email or name)
- **Students/Others**: currently see all teams (can be restricted later)

### Notes
- This is frontend-only filtering for UI purposes. Backend authorization is not implemented yet.
- Falls back to showing all teams if role/email are not set in `localStorage` (maintains current behavior until login is fully wired).
- Login/authentication changes are out of scope for this PR.

### Testing
- Verify professors see all teams
- Verify TAs only see their assigned teams
- Verify team leads only see their own team
- Verify fallback behavior when `localStorage` values are missing