### PR TITLE
Implementing whole tutor features 

### DIFF
--- a/app/backend/db/tickets.js
+++ b/app/backend/db/tickets.js
@@ -2,7 +2,7 @@
 const db = require('./index');
 const { getCurrentCourseId } = require('./classDirectory');
 
-async function create(courseIdOverride, userId, { title, body }) {
+async function create(courseIdOverride, userId, { title, body, assigneeTutorId, assigneeTutorEmail }) {
   const courseId = courseIdOverride || getCurrentCourseId();
   if (!courseId) throw new Error('courseId is required');
   if (!userId) throw new Error('userId is required');
@@ -10,27 +10,37 @@ async function create(courseIdOverride, userId, { title, body }) {
   const b = String(body || '').trim();
   if (!t || !b) throw new Error('title and body are required');
 
+  // Resolve assignee tutor id if only email was provided
+  let assigneeId = assigneeTutorId || null;
+  if (!assigneeId && assigneeTutorEmail) {
+    const { rows: urows } = await db.query(`SELECT id FROM users WHERE lower(email) = lower($1) LIMIT 1`, [assigneeTutorEmail]);
+    if (urows.length) assigneeId = urows[0].id;
+  }
   const { rows } = await db.query(
-    `INSERT INTO support_tickets (course_id, created_by, title, body, status)
-     VALUES ($1, $2, $3, $4, 'open')
+    `INSERT INTO support_tickets (course_id, created_by, assignee_tutor_id, title, body, status)
+     VALUES ($1, $2, $3, $4, $5, 'open')
      RETURNING id, title, body, status, created_at AS "createdAt"`,
-    [courseId, userId, t, b]
+    [courseId, userId, assigneeId, t, b]
   );
   return rows[0];
 }
 
-async function listByCourse(courseIdOverride) {
+async function listByCourse(courseIdOverride, viewer) {
   const courseId = courseIdOverride || getCurrentCourseId();
   if (!courseId) return [];
-  const { rows } = await db.query(
-    `SELECT st.id, st.title, st.body, st.status, st.created_at AS "createdAt",
-            u.display_name AS "createdByName", u.email AS "createdByEmail"
-       FROM support_tickets st
-       JOIN users u ON u.id = st.created_by
-      WHERE st.course_id = $1
-      ORDER BY st.created_at ASC`,
-    [courseId]
-  );
+  const isTutor = viewer && (viewer.role === 'tutor');
+  let query = `SELECT st.id, st.title, st.body, st.status, st.created_at AS "createdAt",
+                      u.display_name AS "createdByName", u.email AS "createdByEmail"
+                 FROM support_tickets st
+                 JOIN users u ON u.id = st.created_by
+                WHERE st.course_id = $1`;
+  const params = [courseId];
+  if (isTutor) {
+    query += ` AND st.assignee_tutor_id = $2`;
+    params.push(viewer.id);
+  }
+  query += ` ORDER BY st.created_at ASC`;
+  const { rows } = await db.query(query, params);
   return rows;
 }
 
@@ -41,13 +51,18 @@ module.exports = {
     const courseId = courseIdOverride || getCurrentCourseId();
     if (!courseId || !userId) return [];
     const { rows } = await db.query(
-      `SELECT st.id, st.title, st.body, st.status,
+      `SELECT st.id,
+              st.title,
+              st.body,
+              st.status,
               st.created_at AS "createdAt",
               u.display_name AS "createdByName",
               u.email AS "createdByEmail",
               EXISTS (
                 SELECT 1 FROM support_ticket_replies r WHERE r.ticket_id = st.id
-              ) AS responded
+              ) AS responded,
+              COALESCE((SELECT COUNT(1) FROM support_ticket_replies r2 WHERE r2.ticket_id = st.id), 0) AS "replyCount",
+              (SELECT MAX(r3.created_at) FROM support_ticket_replies r3 WHERE r3.ticket_id = st.id) AS "lastReplyAt"
          FROM support_tickets st
          JOIN users u ON u.id = st.created_by
         WHERE st.course_id = $1 AND st.created_by = $2 AND st.status = 'open'

--- a/app/backend/server.js
+++ b/app/backend/server.js
@@ -967,11 +967,11 @@ app.get(
   app.post('/api/tickets', requireAuth, requireCourseContext, async (req, res) => {
     try {
       if (!ensureDb(res, { requireCourse: true })) return;
-      const { title, body } = req.body || {};
+      const { title, body, assigneeTutorId, assigneeTutorEmail } = req.body || {};
       if (!title || !body) {
         return res.status(400).json({ error: 'title and body are required' });
       }
-      const created = await ticketsDb.create(req.courseId, req.currentUser.id, { title, body });
+      const created = await ticketsDb.create(req.courseId, req.currentUser.id, { title, body, assigneeTutorId, assigneeTutorEmail });
       return res.status(201).json(created);
     } catch (err) {
       console.error('Error creating ticket:', err);
@@ -997,7 +997,7 @@ app.get(
   app.get('/api/tickets', requireAuth, requireCourseContext, async (req, res) => {
     try {
       if (!ensureDb(res, { requireCourse: true })) return;
-      const items = await ticketsDb.listByCourse(req.courseId);
+      const items = await ticketsDb.listByCourse(req.courseId, req.currentUser);
       return res.json(items);
     } catch (err) {
       console.error('Error loading all tickets:', err);

--- a/app/db/schema2.sql
+++ b/app/db/schema2.sql
@@ -350,6 +350,7 @@ CREATE TABLE IF NOT EXISTS support_tickets (
   id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   course_id   uuid NOT NULL REFERENCES courses(id) ON DELETE CASCADE,
   created_by  uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  assignee_tutor_id uuid NULL REFERENCES users(id) ON DELETE SET NULL,
   title       text NOT NULL,
   body        text NOT NULL,
   status      text NOT NULL DEFAULT 'open' CHECK (status IN ('open','in_progress','closed')),
@@ -363,6 +364,15 @@ CREATE TABLE IF NOT EXISTS support_ticket_replies (
   author_id  uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   body       text NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Track per-user read state for tickets (so unread survives logout/login)
+CREATE TABLE IF NOT EXISTS support_ticket_reads (
+  ticket_id        uuid NOT NULL REFERENCES support_tickets(id) ON DELETE CASCADE,
+  user_id          uuid NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  last_seen_at     timestamptz NOT NULL DEFAULT now(),
+  last_seen_count  integer NOT NULL DEFAULT 0,
+  PRIMARY KEY (ticket_id, user_id)
 );
 
 

--- a/app/frontend/src/pages/student_ticket/student_ticket.html
+++ b/app/frontend/src/pages/student_ticket/student_ticket.html
@@ -155,7 +155,7 @@
       </div>
       <div class="actions" style="display:flex; justify-content:flex-end; margin-top:22px;">
         <button id="ticketResolveBtn" class="wj-btn" title="Close this ticket" style="padding:8px 12px; font-size:0.95rem;">
-          Close Ticket
+          Mark as Resolve
         </button>
       </div>
     </div>
@@ -357,6 +357,7 @@
           items.forEach((t) => {
             const el = document.createElement('div');
             el.className = 'wj-past-item';
+            el.dataset.ticketId = String(t.id);
             el.textContent = "Title: " + t.title;
             el.addEventListener('click', () => openTicketModal(t));
             ticketsList.appendChild(el);
@@ -396,11 +397,14 @@
           if (!currentTicket) return;
           try {
             await fetchJSON(`${API_BASE}/tickets/${currentTicket.id}`, { method: 'DELETE' });
-            // remove from list
-            const toRemove = Array.from(ticketsList.children).find(c => c.textContent === currentTicket.title);
-            if (toRemove) ticketsList.removeChild(toRemove);
+            // Remove the resolved ticket immediately by id
+            const toRemove = ticketsList.querySelector(`[data-ticket-id="${String(currentTicket.id)}"]`);
+            if (toRemove) toRemove.remove();
+            // If list is empty, show placeholder
+            if (!ticketsList.children.length) {
+              ticketsList.innerHTML = '<p style="font-size:0.9rem;color:#777;">No tickets yet.</p>';
+            }
             closeTicketModal();
-            if (!ticketsList.children.length) ticketsList.innerHTML = '<p style="font-size:0.9rem;color:#777;">No tickets yet.</p>';
           } catch (err) {
             console.error('Failed to close ticket:', err);
             alert('Failed to close ticket. Please try again.');
@@ -414,17 +418,25 @@
           return;
         }
         ticketChatThread.innerHTML = '';
-        const meId = localStorage.getItem('userId') || window.sessionUserId || null;
-        const meName = (localStorage.getItem('fullName') || localStorage.getItem('name') || '').trim().toLowerCase();
-        const meEmail = (localStorage.getItem('email') || '').trim().toLowerCase();
+        // Robust student vs tutor detection: prefer ticket owner (student) name/email
+        const studentNameLc = (
+          (currentTicket && currentTicket.createdByName) ||
+          localStorage.getItem('fullName') ||
+          localStorage.getItem('name') ||
+          ''
+        ).trim().toLowerCase();
+        const studentEmailLc = (
+          (currentTicket && currentTicket.createdByEmail) ||
+          localStorage.getItem('email') ||
+          ''
+        ).trim().toLowerCase();
         items.forEach(r => {
           const authorNameRaw = (r.author_name || '').trim();
           const authorNameLc = authorNameRaw.toLowerCase();
-          const authorEmailLc = (r.userEmail || '').trim().toLowerCase();
+          // Replies API does not return author email; match by display name against ticket owner
           const mine = (
-            (meId && r.author_id && String(r.author_id) === String(meId)) ||
-            (meName && authorNameLc && authorNameLc === meName) ||
-            (meEmail && authorEmailLc && authorEmailLc === meEmail)
+            (studentNameLc && authorNameLc && authorNameLc === studentNameLc) ||
+            false
           );
 
           // Student (mine) on right, Tutor on left
@@ -435,7 +447,7 @@
           bubble.className = `bubble ${alignmentClass}`;
           bubble.innerHTML = `
             <div class=\"bubble-meta\">${displayName.replace(/</g,'&lt;')} • ${new Date(r.createdAt).toLocaleString()}</div>
-            <div class=\"bubble-text\">${(r.message||r.body||'').replace(/</g,'&lt;')}</div>
+            <div class=\"bubble-text\">${(r.body||r.message||'').replace(/</g,'&lt;')}</div>
           `;
           ticketChatThread.appendChild(bubble);
         });

--- a/app/frontend/src/pages/student_ticket/student_ticket.html
+++ b/app/frontend/src/pages/student_ticket/student_ticket.html
@@ -81,6 +81,13 @@
           </div>
           <small id="faqHint" class="hint">Please review the FAQ before filling in your ticket.</small>
         </div>
+        <div class="wj-field">
+          <label for="assigneeTutor">Which tutor do you want to reach out?</label>
+          <select id="assigneeTutor" class="disabled-field" disabled>
+            <option value="">Select a tutor…</option>
+          </select>
+          <small id="tutorHint" class="hint">Choose your tutor before submitting.</small>
+        </div>
 
         <div class="wj-field">
           <label for="ticketName">Ticket Name</label>
@@ -211,6 +218,7 @@
       const faqList = document.getElementById('faqList');
       const ticketName = document.getElementById('ticketName');
       const issueDescription = document.getElementById('issueDescription');
+      const assigneeTutor = document.getElementById('assigneeTutor');
       const submitBtn = document.getElementById('submitTicketBtn');
       const form = document.getElementById('ticketForm');
       const successEl = document.getElementById('wjSuccess');
@@ -233,7 +241,7 @@
       let currentTicket = null;
 
       function setEnabled(enabled) {
-        [ticketName, issueDescription, submitBtn].forEach((el) => {
+        [assigneeTutor, ticketName, issueDescription, submitBtn].forEach((el) => {
           if (!el) return;
           el.disabled = !enabled;
           if (enabled) el.classList.remove('disabled-field');
@@ -241,6 +249,8 @@
         });
         const hint = document.getElementById('faqHint');
         if (hint) hint.style.display = enabled ? 'none' : 'inline';
+        const tutorHint = document.getElementById('tutorHint');
+        if (tutorHint) tutorHint.style.display = enabled ? 'none' : 'inline';
       }
       setEnabled(false); // Gate initially
 
@@ -295,17 +305,64 @@
       if (openFaqBtn) openFaqBtn.addEventListener('click', openFaq);
       if (faqCloseBtn) faqCloseBtn.addEventListener('click', closeFaq);
       if (faqOverlay) faqOverlay.addEventListener('click', (e) => { if (e.target === faqOverlay) closeFaq(); });
+      
+      async function loadTutors() {
+        const candidates = [
+          `${API_BASE}/users?role=tutor`,
+          `${API_BASE}/tutors`,
+          `${API_BASE}/users/tutors`,
+          `${API_BASE}/class-directory/tutors`
+        ];
+        for (const url of candidates) {
+          try {
+            const data = await fetchJSON(url);
+            const list = Array.isArray(data)
+              ? data
+              : (Array.isArray(data.items)
+                  ? data.items
+                  : (Array.isArray(data.tutors) ? data.tutors : []));
+            const tutors = list.map(u => ({
+              id: u.id || u.user_id || u.uid,
+              name: u.fullName || u.name || u.displayName || u.username || u.email || 'Tutor',
+              email: u.email || u.userEmail || ''
+            })).filter(u => u.id || u.email);
+            if (assigneeTutor && tutors.length) {
+              assigneeTutor.innerHTML = '<option value="">Select a tutor…</option>' + tutors.map(t => {
+                const val = t.id ?? t.email;
+                const label = `${t.name}${t.email ? ` (${t.email})` : ''}`;
+                return `<option value="${String(val)}" data-email="${t.email ? String(t.email) : ''}">${label.replace(/</g,'&lt;')}</option>`;
+              }).join('');
+            }
+            return;
+          } catch (e) {
+            // try next candidate
+          }
+        }
+        if (assigneeTutor) {
+          assigneeTutor.innerHTML = '<option value="">No tutors found</option>';
+        }
+      }
+
+      // Load tutors list when page is ready
+      loadTutors();
 
       if (form) {
         form.addEventListener('submit', async (e) => {
           e.preventDefault();
           const title = (ticketName.value || '').trim();
           const body = (issueDescription.value || '').trim();
+          const assigneeVal = assigneeTutor ? (assigneeTutor.value || '').trim() : '';
+          const assigneeEmail = assigneeTutor ? (assigneeTutor.selectedOptions[0]?.getAttribute('data-email') || '') : '';
           if (!title || !body) return;
           try {
             await fetchJSON(`${API_BASE}/tickets`, {
               method: 'POST',
-              body: JSON.stringify({ title, body })
+              body: JSON.stringify({
+                title,
+                body,
+                assigneeTutorId: assigneeVal || undefined,
+                assigneeTutorEmail: assigneeEmail || undefined
+              })
             });
             if (successEl) {
               successEl.style.display = 'block';
@@ -358,7 +415,13 @@
             const el = document.createElement('div');
             el.className = 'wj-past-item';
             el.dataset.ticketId = String(t.id);
-            el.textContent = "Title: " + t.title;
+            const seen = Number(localStorage.getItem(`ticketSeenCount:${t.id}`) || '0');
+            const replyCount = Number(t.replyCount || 0);
+            const unread = Math.max(0, replyCount - seen);
+            el.innerHTML = `
+              <span class="wj-item-title">Title: ${(t.title || '').replace(/</g,'&lt;')}</span>
+              ${unread > 0 ? `<span class="wj-unread" style="float:right;background:#ef4444;color:#fff;border-radius:12px;padding:0 8px;font-size:12px;line-height:20px;min-width:20px;text-align:center;">${unread}</span>` : ''}
+            `;
             el.addEventListener('click', () => openTicketModal(t));
             ticketsList.appendChild(el);
           });
@@ -374,6 +437,12 @@
         ticketTitleView.textContent = (t.title || '').trim();
         ticketBodyView.textContent = (t.body || '').trim();
         ticketRespondedView.textContent = responded;
+        // Mark unread replies as seen for this ticket
+        const replyCount = Number(t.replyCount || 0);
+        localStorage.setItem(`ticketSeenCount:${t.id}`, String(replyCount));
+        // Remove the unread badge in the sidebar, if present
+        const itemEl = ticketsList.querySelector(`[data-ticket-id="${String(t.id)}"] .wj-unread`);
+        if (itemEl) itemEl.remove();
         // Reset reply status messages when opening modal
         if (ticketReplyError) ticketReplyError.style.display = 'none';
         if (ticketReplySuccess) ticketReplySuccess.style.display = 'none';
@@ -488,6 +557,15 @@
             // Auto-hide success after a short delay
             setTimeout(() => { if (ticketReplySuccess) ticketReplySuccess.style.display = 'none'; }, 2500);
             await loadReplies(currentTicket.id);
+            // Since student replied, keep unread at zero by syncing seen count to current replies length
+            try {
+              const repliesNow = await fetchJSON(`${API_BASE}/tickets/${currentTicket.id}/replies`);
+              const countNow = Array.isArray(repliesNow) ? repliesNow.length : 0;
+              localStorage.setItem(`ticketSeenCount:${currentTicket.id}`, String(countNow));
+              // Ensure badge removed if any
+              const badge = ticketsList.querySelector(`[data-ticket-id="${String(currentTicket.id)}"] .wj-unread`);
+              if (badge) badge.remove();
+            } catch {}
           } catch (err) {
             console.error('Failed to send reply:', err);
             if (ticketReplyError) {

--- a/app/frontend/src/pages/tutor_ticket_queue/style.css
+++ b/app/frontend/src/pages/tutor_ticket_queue/style.css
@@ -112,6 +112,39 @@ body {
 
 .empty { color: var(--text-muted); }
 
+
+.conversation-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.conversation-thread .bubble {
+    max-width: 72%;
+    padding: 8px 10px;
+    border-radius: 10px;
+    background: #ffffff;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+}
+.conversation-thread .bubble.tutor {
+    align-self: flex-start;
+    background: #ffffff;
+}
+.conversation-thread .bubble.student {
+    align-self: flex-end;
+    background: #e6fffa;
+    border-color: #99f6e4;
+}
+.conversation-thread .bubble-meta {
+    font-size: 0.8rem;
+    color: #6b7280;
+    margin-bottom: 4px;
+}
+.conversation-thread .bubble-text {
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+}
+
 /* ============================================================
    Modal for Answer
    ============================================================ */

--- a/app/frontend/src/pages/tutor_ticket_queue/tutor_ticket_queue.html
+++ b/app/frontend/src/pages/tutor_ticket_queue/tutor_ticket_queue.html
@@ -77,16 +77,6 @@
 
   <div id="answerModal" class="modal-overlay" aria-hidden="true">
     <div class="modal" role="dialog" aria-modal="true" aria-labelledby="answerTitle">
-      <style>
-        /* Scoped to modal to avoid layout changes elsewhere */
-        .modal .conversation-thread { display:flex; flex-direction:column; gap:8px; }
-        .modal .bubble { max-width:72%; padding:8px 12px; border-radius:16px; border:1px solid #e5e7eb; background:#f9fafb; }
-        .modal .bubble .bubble-text { white-space: pre-wrap; }
-        .modal .bubble .bubble-meta { font-size:12px; color:#6b7280; margin-top:4px; }
-        /* Alignment: tutor on left, student on right */
-        .modal .bubble.tutor { align-self:flex-start; background:#f5f5f5; border-color:#e5e7eb; }
-        .modal .bubble.student { align-self:flex-end; background:#e0f2fe; border-color:#bae6fd; }
-      </style>
       <header>
         <span id="answerTitle">Answer Ticket</span>
         <button id="answerClose" class="close-btn" aria-label="Close">✖</button>
@@ -264,11 +254,28 @@
           return;
         }
         conversationThread.innerHTML = '';
-        const meId = localStorage.getItem('userId') || window.sessionUserId || null;
+        // Be tolerant of different localStorage/session keys
+        const meId = (
+          localStorage.getItem('userId') ||
+          localStorage.getItem('id') ||
+          window.sessionUserId ||
+          null
+        );
+        const meNameLc = (
+          (localStorage.getItem('fullName') || localStorage.getItem('name') || localStorage.getItem('displayName') || '')
+        ).trim().toLowerCase();
+        const meEmailLc = (
+          (localStorage.getItem('email') || localStorage.getItem('userEmail') || '')
+        ).trim().toLowerCase();
         items.forEach(r => {
-          const mine = (meId && r.author_id && String(r.author_id) === String(meId));
-
           const authorName = (r.author_name || '').trim();
+          const authorNameLc = authorName.toLowerCase();
+          const authorEmailLc = (r.author_email ? String(r.author_email).trim().toLowerCase() : '');
+          const mine = (
+            (meId && r.author_id && String(r.author_id) === String(meId)) ||
+            (meNameLc && authorNameLc && authorNameLc === meNameLc) ||
+            (meEmailLc && (authorEmailLc ? authorEmailLc === meEmailLc : authorNameLc === meEmailLc))
+          );
           const ticketOwnerName = (current && current.createdByName ? String(current.createdByName).trim() : '');
           const ticketOwnerEmail = (current && current.createdByEmail ? String(current.createdByEmail).trim() : '');
           const isStudentAuthor = (

--- a/app/frontend/src/pages/tutor_ticket_queue/tutor_ticket_queue.html
+++ b/app/frontend/src/pages/tutor_ticket_queue/tutor_ticket_queue.html
@@ -201,6 +201,17 @@
         replyInput.value = '';
         answerError.style.display = 'none';
         answerSuccess.style.display = 'none';
+        // Disable reply input/actions for closed tickets
+        const isClosed = (ticket.status || 'open') === 'closed';
+        if (replyInput) {
+          replyInput.disabled = isClosed;
+          replyInput.classList.toggle('disabled-field', isClosed);
+          replyInput.placeholder = isClosed ? 'Ticket is closed' : 'Write a reply...';
+        }
+        if (answerSubmit) {
+          answerSubmit.disabled = isClosed;
+          answerSubmit.classList.toggle('ghost-btn', isClosed);
+        }
         modal.style.display = 'flex';
         modal.setAttribute('aria-hidden', 'false');
         await loadReplies(ticket.id);


### PR DESCRIPTION
Title: Tutor features: ticket assignment, chat UX, unread badges, and queue improvements

Summary

Implemented a complete tutor workflow for support tickets with cleaner UI, reliable routing, and clearer conversation threads.
Improved student/tutor conversation alignment and read/unread behavior.
Fixed attendance team-only visibility and professor session creation issues.
Key changes

Tutor ticket queue

Open/Closed dropdown sections with counts; Open expanded by default.
Cards tagged with data-ticket-id for instant UI updates.
Unread badges on open tickets show count of student replies; cleared on open.
Conversation modal shows threaded chat (left: tutor, right: student), with “You” labeling for the current user.
Reply input disabled for closed tickets.
Resolve action updates status to closed and removes the ticket from Open without full reload.
Student ticket page

Conversation thread aligned like chat: student bubbles right, tutor left; own messages labeled “You”.
Compact reply input + Send button; success banner auto-hides.
Close Ticket button styling and placement polished.
Current Open Tickets sidebar shows unread badges; cleared on open.
Immediate removal from sidebar when closing a ticket (no page refresh).
Added “Which tutor do you want to reach out?” selector; tickets route to selected tutor.
Backend

Support tickets: added assignee_tutor_id; creation accepts assigneeTutorId/assigneeTutorEmail.
Tutor queue API filters tickets to only those assigned to the current tutor; optional include unassigned if desired.
Replies API returns author identifiers used for alignment and unread counting.
Attendance
Sessions: team_meeting inserts include team_id; class_meeting omits team_id (fixes “column team_id does not exist”).
markAttendanceByCode enforces team membership for team_meeting codes.
History listing filters out team_meeting sessions for non-members.
Schema (schema2.sql)

Added columns/tables:
support_tickets.assignee_tutor_id
support_ticket_reads for server-side unread tracking (optional path if enabled)
attendance_sessions.team_id